### PR TITLE
Cover an NPE when setting a MenuItem's layout to null

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,6 @@
+7.8.1-FORK (17-01-2024)
+- Bug fix: Cover an NPE when a MenuItem's layout was set to null [#qubIT-Omnis-8308]
+
 7.8.0-FORK (13-01-2024)
 - New feature: Adapts MenuItem and MenuFunctionality to new Layout changes [#qubIT-Omnis-7713]
 

--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/domain/MenuItem.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/domain/MenuItem.java
@@ -358,7 +358,8 @@ public abstract class MenuItem extends MenuItem_Base implements com.qubit.terra.
 
     @Override
     public void setLayoutObject(Layout layout) {
-        setLayout(layout.getKey());
+        String layoutKey = layout == null ? null : layout.getKey();
+        setLayout(layoutKey);
     }
 
     @Override


### PR DESCRIPTION
Relates with: #qubIT-Omnis-8308