### PR TITLE
Adds a fail-safe login template for themes with no login layout 

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Improvement: Changes the default application theme during bootstrapping from default to fenixedu-omnis-theme [#qubIT-Fenix-7800]
+- Bug fix: Adds a fail-safe login layout for cases where the application's theme does not have a login layout [#qubIT-Fenix-7798]
 - Bug fix: Correcting SSO 3rd party providers injection into layout [#qubIT-Fenix-7767]
 
 7.8.5-FORK (07-10-2025)

--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/domain/PortalConfiguration.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/domain/PortalConfiguration.java
@@ -23,9 +23,9 @@ import pt.ist.fenixframework.Atomic.TxMode;
 /**
  * A {@link PortalConfiguration} contains the configuration for the installed application, as well as the entry point for the
  * installed functionality tree.
- * 
+ *
  * @author João Carvalho (joao.pedro.carvalho@tecnico.ulisboa.pt)
- * 
+ *
  */
 public class PortalConfiguration extends PortalConfiguration_Base {
 
@@ -38,9 +38,9 @@ public class PortalConfiguration extends PortalConfiguration_Base {
         setApplicationSubTitle(new LocalizedString(I18N.getLocale(), "Application Subtitle"));
         setApplicationCopyright(new LocalizedString(I18N.getLocale(), "Organization Copyright"));
         setHtmlTitle(getApplicationTitle());
-        setTheme("default");
-        try (InputStream stream =
-                PortalConfiguration.class.getClassLoader().getResourceAsStream("META-INF/resources/img/logo_bennu.svg")) {
+        setTheme("fenixedu-omnis-theme");
+        try (InputStream stream = PortalConfiguration.class.getClassLoader()
+                .getResourceAsStream("META-INF/resources/img/logo_bennu.svg")) {
             if (stream == null) {
                 logger.error("Default logo not found in: img/logo_bennu.svg");
             } else {
@@ -50,8 +50,8 @@ public class PortalConfiguration extends PortalConfiguration_Base {
         } catch (IOException e) {
             logger.error("Default logo could not be read from: img/logo_bennu.svg");
         }
-        try (InputStream stream =
-                PortalConfiguration.class.getClassLoader().getResourceAsStream("META-INF/resources/img/favicon_bennu.png")) {
+        try (InputStream stream = PortalConfiguration.class.getClassLoader()
+                .getResourceAsStream("META-INF/resources/img/favicon_bennu.png")) {
             if (stream == null) {
                 logger.error("Default favicon not found in: img/favicon_bennu.png");
             } else {
@@ -80,7 +80,7 @@ public class PortalConfiguration extends PortalConfiguration_Base {
 
     /**
      * Returns the singleton instance of {@link PortalConfiguration} for this application.
-     * 
+     *
      * @return
      *         The one and only instance of {@link PortalConfiguration}
      */
@@ -117,10 +117,10 @@ public class PortalConfiguration extends PortalConfiguration_Base {
 
     /**
      * Returns the checksum of the current application's logo.
-     * 
+     *
      * This value is meant to be used as a mechanism for cache busting, as as such, its correctness is not guarranteed, and it may
      * even be {@code null}.
-     * 
+     *
      * @return
      *         The checksum of the application's logo. May be null
      */

--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/servlet/PortalLoginServlet.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/servlet/PortalLoginServlet.java
@@ -4,11 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
@@ -66,6 +64,7 @@ public class PortalLoginServlet extends HttpServlet {
 
     private static final long serialVersionUID = -4298321185506045304L;
     public static final String RESOURCE_NOT_FOUND_HTML = "<html><body><strong>Could not find: {0} </strong></body></html>";
+    protected static final String DEFAULT_LOGIN_RESOURCE = "/bennu-portal/login.html";
 
     private static ThreadLocal<Map<String, Object>> contextExtensions = new ThreadLocal<Map<String, Object>>();
 
@@ -84,8 +83,9 @@ public class PortalLoginServlet extends HttpServlet {
                 if (stream != null) {
                     return new InputStreamReader(stream, StandardCharsets.UTF_8);
                 } else {
-                    Log.error(LogContextStandards.OMNIS_PRESENTATION, "Could not find template " + layoutPath);
-                    return new StringReader(MessageFormat.format(RESOURCE_NOT_FOUND_HTML, layoutPath));
+                    Log.error(LogContextStandards.OMNIS_PRESENTATION,
+                            "Could not find login template " + layoutPath + ", redirecting to default login layout");
+                    return new InputStreamReader(context.getResourceAsStream(DEFAULT_LOGIN_RESOURCE), StandardCharsets.UTF_8);
                 }
             }
         }).cacheActive(!BennuPortalConfiguration.getConfiguration().themeDevelopmentMode()).build();


### PR DESCRIPTION
Adds a fail-safe login template for themes with no login layout and sets the default application-theme on startup to fenixedu-omnis-theme

Relates with: #qubIT-Fenix-7798 && #qubIT-Fenix-7800